### PR TITLE
Fix inner Russian quotation marks

### DIFF
--- a/lib/Text/Amuse/Preprocessor/TypographyFilters.pm
+++ b/lib/Text/Amuse/Preprocessor/TypographyFilters.pm
@@ -181,8 +181,8 @@ sub characters {
             ru => {
                    ldouble => "\x{ab}",
                    rdouble => "\x{bb}",
-                   lsingle => "\x{2018}",
-                   rsingle => "\x{2019}",
+                   lsingle => "\x{201e}",
+                   rsingle => "\x{201c}",
                    apos    => "\x{2019}",
                    emdash  => "\x{2014}",
                    endash  => "-",

--- a/t/testfiles/full.out.muse
+++ b/t/testfiles/full.out.muse
@@ -1,11 +1,11 @@
 #title Test
 #lang ru
 
-Hello [1] there [2] «hullo», ‘hullo’ [3] [1978]
+Hello [1] there [2] «hullo», „hullo“ [3] [1978]
 [1] ààà
 [2] čČč
 
-‘Hello’ — «there»!!! <verbatim>"Hello" [1]</verbatim>
+„Hello“ — «there»!!! <verbatim>"Hello" [1]</verbatim>
 [3] three čČč Да поехал
 
 <example>

--- a/t/testfiles/ru.muse
+++ b/t/testfiles/ru.muse
@@ -2,8 +2,8 @@
 
 common: fi fl ffi ffl ff fi fl ffi ffl ff
 
-This is «my quotation» and ‘this’ and that’s all This is «my
-quotation» and ‘this’ and that’s all
+This is «my quotation» and „this“ and that’s all This is «my
+quotation» and „this“ and that’s all
 
 10-15 and 100000-150000,10-15
  - a list
@@ -14,7 +14,7 @@ In the ’80 and ’90
 
 — not a list — not really — no
 
-‘this’ and ‘this.’
+„this“ and „this.“
 
 «this» and «this.»
 
@@ -22,7 +22,7 @@ In the ’80 and ’90
 
 «this« and «this«
 
-‘this‘ and ‘this‘
+„this„ and „this„
 
 «my» «quote»
 
@@ -36,22 +36,22 @@ and — here we are — the — ósecondÓ — example
 
 hello.» hell’o»
 
-«?hello?» «?hello?» «l’amour» ‘amour’
+«?hello?» «?hello?» «l’amour» „amour“
 
-This is «ómy quotationÓ» and ‘Óthisó’ and that’s all
+This is «ómy quotationÓ» and „Óthisó“ and that’s all
 
-«This is a ‘quotation’».
+«This is a „quotation“».
 
-«This is a ‘quotation’.»
+«This is a „quotation“.»
 
 sólo Sólo sólobla blasólo sólobla blasólo blasólobla
 
 l’«amore» l’«amore» l’ardore
 
-«хотите присоединиться «к» ‘ордену’ Библиотекарей»
-‘хотите присоединиться «к» ‘ордену’ Библиотекарей’
-«‘хотите’» ‘«хотите»’ ‘«хотите»’
-‘«хотите»’ «‘хотите’» «‘хотите’»
+«хотите присоединиться «к» „ордену“ Библиотекарей»
+„хотите присоединиться «к» „ордену“ Библиотекарей“
+«„хотите“» „«хотите»“ „«хотите»“
+„«хотите»“ «„хотите“» «„хотите“»
 
 This was -not not-here nor-here-x all. —
 This was all. —


### PR DESCRIPTION
Russian language uses « and » for outer marks and
„“ for inner marks.

Previously preprocessor used single inner marks,
which are not used in Russian at all.

See https://russian.stackexchange.com/questions/1470/quotation-marks